### PR TITLE
connect関数の第二引数の指定が必要なかったのでトルツメ

### DIFF
--- a/src/pages/CounterPage.js
+++ b/src/pages/CounterPage.js
@@ -58,5 +58,4 @@ class CounterPage extends Component {
 
 export default connect(
   ({ counter }) => ({ counter }),
-  dispatch => ({ dispatch }),
 )(CounterPage)


### PR DESCRIPTION
何も書かなければ、dispatch関数が自動的に`this.props`に渡される。
connect関数の仕様みたい。
